### PR TITLE
Add 'flexiflow-ignore' version set

### DIFF
--- a/multi-site/version_sets/flexiflow-ignore.yaml
+++ b/multi-site/version_sets/flexiflow-ignore.yaml
@@ -1,0 +1,21 @@
+---
+Id: flexiflow-ignore
+Apply: false
+Components:
+- Name: flexiflow
+  Type: ContentPackage
+  Version: ignore
+Description: Ignore Flexiflow content.
+Documentation: |
+  Ignores the ``flexiflow`` content pack.  Used primarily to
+  demo adding flexiflow which is removed, then add this 
+  VersionSet to the DRP Endpoint, and then the flexiflow
+  content will be ignored on that endpoint.
+
+Meta:
+  color: orange
+  icon: lab
+Params: {}
+Plugins: []
+Type: version_sets
+


### PR DESCRIPTION
Allows demo of adding the `flexiflow-ignore` VS to a DRP Endpoint to allow the endpoint to not enforce removal of the content pack if added.